### PR TITLE
Optimize preference settings saved

### DIFF
--- a/src/store/plugins/preference-plugin.ts
+++ b/src/store/plugins/preference-plugin.ts
@@ -115,9 +115,8 @@ export function preferencePlugin({ pinia, options, store, app }: PiniaPluginCont
     useEventListener('beforeunload', () => {
       clearInterval(checkStorageInterval)
 
-      // 如果用户清除了存储，则不重新保存偏好
+      // 如果用户清除了存储,恢复到默认值
       if (userClearedStorage) {
-        // 恢复到默认值
         store.$restoreAllPreference()
       }
 

--- a/src/store/plugins/preference-plugin.ts
+++ b/src/store/plugins/preference-plugin.ts
@@ -32,7 +32,6 @@ declare module 'pinia' {
 
 const { copy } = useClipboard()
 let registedBeforeunloadEvent = false
-let userClearedStorage = false // 标记用户是否清除了存储
 const storeIdToKeysInitialValueRecord = new Map<string, {
   prefixPath: string
   initialValueMap: Map<string, any>
@@ -97,36 +96,13 @@ export function preferencePlugin({ pinia, options, store, app }: PiniaPluginCont
   if (!registedBeforeunloadEvent) {
     registedBeforeunloadEvent = true
 
-    // 监听storage事件，检测用户是否清除了localStorage
-    useEventListener('storage', (e) => {
-      if (e.key === 'preference' && e.newValue === null) {
-        userClearedStorage = true
-      }
-    })
-
-    // 定期检查localStorage是否被清空（处理同标签页清除的情况）
-    const checkStorageInterval = setInterval(() => {
-      const currentPreference = localStorage.getItem('preference')
-      if (currentPreference === null && !userClearedStorage) {
-        userClearedStorage = true
-      }
-    }, 1000)
-
     useEventListener('beforeunload', () => {
-      clearInterval(checkStorageInterval)
-
-      // 如果用户清除了存储,恢复到默认值
-      if (userClearedStorage) {
-        store.$restoreAllPreference()
-      }
-
       localStorage.setItem('preference', JSON.stringify(getAllPreference(pinia)))
     })
   }
 
   app.onUnmount(() => {
     registedBeforeunloadEvent = false
-    userClearedStorage = false // 重置标记
     localStorage.removeItem('preference')
     storeIdToKeysInitialValueRecord.clear()
     delete (store as any).$copyAllPreference


### PR DESCRIPTION
# 解决用户清除网站数据后偏好仍被恢复的问题

## 问题描述
当用户主动清除网站数据时，偏好设置会在页面卸载时被重新保存，违背了用户重置的意图。
<img width="1077" height="743" alt="image" src="https://github.com/user-attachments/assets/32b98fae-722c-46f6-b7d4-39fa97bf7aa4" />


## 解决方案
检测机制，监控localStorage是否被用户清除,在beforeunload事件中判断用户意图，避免重新保存已清除的偏好.